### PR TITLE
Allow fixtures return generators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4

--- a/src/Test.php
+++ b/src/Test.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace EasyTest;
+
+use Generator;
+
+class Test {
+
+	public function __construct(
+		private TestSuiteInterface $testSuite,
+		private string $function,
+		private array $arguments,
+	) {}
+
+	public function run() {
+		$testArguments = TestArguments::prepare($this->testSuite, $this->arguments);
+		if ($testArguments->hasGenerators()) {
+			$this->runWithGenerator($testArguments);
+		} else {
+			$this->runFunction($testArguments->getPrepared());
+		}
+	}
+
+	private function runWithGenerator(TestArguments $arguments) {
+		$generatorInArgumens = $arguments->findGenerator();
+		$preparedArguments = $arguments->getPrepared();
+		$generator = $preparedArguments[$generatorInArgumens];
+		if (!$generator instanceof Generator) {
+			throw new \RuntimeException("Fixture for {$this->function} did not return an expected generator");
+		}
+
+		foreach ($generator as $value) {
+			$preparedArguments[$generatorInArgumens] = $value;
+			$this->runFunction($preparedArguments);
+		}
+	}
+
+	private function runFunction(array $arguments) {
+		foreach ($this->testSuite->getSetups() as $setupFunction) {
+			$setupFunction();
+		}
+		call_user_func_array($this->function, $arguments);
+		foreach ($this->testSuite->getTearDowns() as $teardownFunction) {
+			$teardownFunction();
+		}
+	}
+}

--- a/src/TestArguments.php
+++ b/src/TestArguments.php
@@ -31,7 +31,7 @@ class TestArguments {
 		return null;
 	}
 
-	public static function prepare(TestSuite $testSuite, array $arguments): self {
+	public static function prepare(TestSuiteInterface $testSuite, array $arguments): self {
 		$preparedArguments = [];
 		foreach ($arguments as $name => $type) {
 			try {

--- a/src/TestArguments.php
+++ b/src/TestArguments.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace EasyTest;
+
+use Generator;
+
+class TestArguments {
+	public function __construct(
+		private array $arguments
+	) {}
+
+	public function getPrepared(): array {
+		return $this->arguments;
+	}
+	
+	public function hasGenerators(): bool {
+		foreach ($this->arguments as $argument) {
+			if ($argument instanceof Generator) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function findGenerator(): ?int {
+		foreach ($this->arguments as $key => $argument) {
+			if ($argument instanceof Generator) {
+				return $key;
+			}
+		}
+		return null;
+	}
+
+	public static function prepare(TestSuite $testSuite, array $arguments): self {
+		$preparedArguments = [];
+		foreach ($arguments as $name => $type) {
+			try {
+				if ($testSuite->hasFixture($name, $type)) {
+					$preparedArguments[] = $name();
+				} else {
+					throw new \RuntimeException("Didn't find fixture for $name");
+				}
+			} catch (\Throwable $e) {
+				throw new \RuntimeException("Fixture for $name failed: " . $e->getMessage());
+			}
+		}
+		
+		return new self($preparedArguments);
+	}
+}

--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -6,10 +6,10 @@ use EasyTest\Attribute\Fixture;
 use EasyTest\Attribute\Ignore;
 use EasyTest\Attribute\Setup;
 use EasyTest\Attribute\TearDown;
-use EasyTest\Attribute\Test;
+use EasyTest\Attribute\Test as TestAttribute;
 use Generator;
 
-class TestSuite {
+final class TestSuite implements TestSuiteInterface {
 
 	private array $functionNames;
 
@@ -47,18 +47,19 @@ class TestSuite {
 		}
 
 		foreach ($reflection->getAttributes() as $attr) {
-			$name = $attr->getName();
-			if ($name === Fixture::class) {
-				$this->fixtures[$reflection->getName()] = $reflection->getReturnType()->getName();
-			} elseif ($name === Test::class) {
-				$this->tests[] = [
-					'function' => $reflection->getName(),
-					'arguments' => $arguments,
-				];
-			} elseif ($name === Setup::class) {
-				$this->setups[] = $reflection->getName();
-			} elseif ($name === TearDown::class) {
-				$this->tearDowns[] = $reflection->getName();
+			switch ($attr->getName()) {
+				case Fixture::class:
+					$this->fixtures[$reflection->getName()] = $reflection->getReturnType()->getName();
+					break;
+				case TestAttribute::class:
+					$this->tests[] = new Test($this, $reflection->getName(), $arguments);
+					break;
+				case Setup::class:
+					$this->setups[] = $reflection->getName();
+					break;
+				case TearDown::class:
+					$this->tearDowns[] = $reflection->getName();
+					break;
 			}
 		}
 	}

--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -7,7 +7,7 @@ use EasyTest\Attribute\Ignore;
 use EasyTest\Attribute\Setup;
 use EasyTest\Attribute\TearDown;
 use EasyTest\Attribute\Test;
-
+use Generator;
 
 class TestSuite {
 
@@ -68,7 +68,11 @@ class TestSuite {
 	}
 
 	public function hasFixture(string $fixtureName, string $fixtureType): bool {
-		return isset($this->fixtures[$fixtureName]) && $this->fixtures[$fixtureName] === $fixtureType;
+		if (!isset($this->fixtures[$fixtureName])) {
+			return false;
+		}
+
+		return $this->fixtures[$fixtureName] === $fixtureType || $this->fixtures[$fixtureName] === Generator::class;
 	}
 
 	public function getSetups(): array {

--- a/src/TestSuiteInterface.php
+++ b/src/TestSuiteInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace EasyTest;
+
+interface TestSuiteInterface {
+	public function prepare(): void;
+	public function getTests(): array;
+	public function hasFixture(string $fixtureName, string $fixtureType): bool;
+	public function getSetups(): array;
+	public function getTearDowns(): array; 
+}

--- a/src/TestSuiteRunner.php
+++ b/src/TestSuiteRunner.php
@@ -2,11 +2,9 @@
 
 namespace EasyTest;
 
-use Generator;
-
 class TestSuiteRunner {
 
-	private TestSuite $testSuite;
+	private TestSuiteInterface $testSuite;
 
 	private int $passes = 0;
 
@@ -14,7 +12,7 @@ class TestSuiteRunner {
 
 	private array $errors = [];
 
-	public function __construct(TestSuite $testSuite) {
+	public function __construct(TestSuiteInterface $testSuite) {
 		$this->testSuite = $testSuite;
 	}
 
@@ -24,30 +22,8 @@ class TestSuiteRunner {
 		$this->errors = [];
 
 		foreach ($this->testSuite->getTests() as $test) {
-			$function = $test['function'];
-			$arguments = $test['arguments'];
-
-			$prepared_arguments = [];
-			foreach ($arguments as $name => $type) {
-				try {
-					if ($this->testSuite->hasFixture($name, $type)) {
-						$prepared_arguments[] = $name();
-					} else {
-						$this->errors[] = new \RuntimeException("Didn't find fixture for $name");
-						continue 2;
-					}
-				} catch (\Throwable $e) {
-					$this->errors[] = new \RuntimeException("Fixture for $name failed: " . $e->getMessage());
-					continue 2;
-				}
-			}
-
 			try {
-				if ($this->hasGenerators($prepared_arguments)) {
-					$this->runGenerator($function, $prepared_arguments);
-				} else {
-					$this->runFunction($function, $prepared_arguments);
-				}
+				$test->run();
 				$this->passes++;
 				yield '.';
 			} catch (\AssertionError $e) {
@@ -57,46 +33,6 @@ class TestSuiteRunner {
 				$this->errors[] = $e;
 				yield 'E';
 			}
-		}
-	}
-
-	private function hasGenerators($arguments): bool {
-		foreach ($arguments as $argument) {
-			if ($argument instanceof Generator) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private function runGenerator($function, $arguments) {
-		$generatorInArgumens = $this->findGenerator($arguments);
-		$generator = $arguments[$generatorInArgumens];
-		if (!$generator instanceof Generator) {
-			throw new \RuntimeException("Test function $function did not return a generator");
-		}
-		foreach ($generator as $value) {
-			$arguments[$generatorInArgumens] = $value;
-			$this->runFunction($function, $arguments);
-		}
-	}
-
-	private function findGenerator($arguments): ?int {
-		foreach ($arguments as $key => $argument) {
-			if ($argument instanceof Generator) {
-				return $key;
-			}
-		}
-		return null;
-	}
-
-	private function runFunction($function, $arguments) {
-		foreach ($this->testSuite->getSetups() as $setupFunction) {
-			$setupFunction();
-		}
-		$function(...$arguments);
-		foreach ($this->testSuite->getTearDowns() as $teardownFunction) {
-			$teardownFunction();
 		}
 	}
 

--- a/tests/test-argument-parser.php
+++ b/tests/test-argument-parser.php
@@ -3,30 +3,27 @@
 namespace EasyTestTest\ArgumentParser;
 
 use EasyTest\Attribute\Fixture;
-use EasyTest\Attribute\Ignore;
-use EasyTest\Attribute\Setup;
-use EasyTest\Attribute\TearDown;
 use EasyTest\Attribute\Test;
 use EasyTest\ArgumentParser;
 
 #[Fixture]
 function parser(): ArgumentParser
 {
-	return new ArgumentParser();
+    return new ArgumentParser();
 }
 
 #[Test]
 function testParser_GetTestsPath_WithEmptyArguments_ReturnsDefaultValue(ArgumentParser $parser): void
 {
-	$parser->parse([]);
-	$testsPath = $parser->getTestsPath('./tests');
-	assert('./tests' === $testsPath);
+    $parser->parse([]);
+    $testsPath = $parser->getTestsPath('./tests');
+    assert('./tests' === $testsPath);
 }
 
 #[Test]
 function testParser_GetTestsPath_WithTestsPathArgument_ReturnsTestsPath(ArgumentParser $parser): void
 {
-	$parser->parse(['a', 'b', 'c']);
-	$testsPath = $parser->getTestsPath();
-	assert('b' === $testsPath);
+    $parser->parse(['a', 'b', 'c']);
+    $testsPath = $parser->getTestsPath();
+    assert('b' === $testsPath);
 }

--- a/tests/test-file-finder.php
+++ b/tests/test-file-finder.php
@@ -8,22 +8,22 @@ use EasyTest\FileFinder;
 
 #[Fixture]
 function fileFinder(): FileFinder {
-	return new FileFinder();
+    return new FileFinder();
 }
 
 #[Test]
 function testFileFinder(FileFinder $fileFinder): void
 {
-	$dirname = dirname(__FILE__) . '/test-file-finder';
-	$expected = [
-		$dirname . '/1.php',
-		$dirname . '/2.php',
-	];
+    $dirname = dirname(__FILE__) . '/test-file-finder';
+    $expected = [
+        $dirname . '/1.php',
+        $dirname . '/2.php',
+    ];
 
-	$generator = $fileFinder->findIn($dirname);
-	$actual = iterator_to_array($generator);
-	sort($actual);
+    $generator = $fileFinder->findIn($dirname);
+    $actual = iterator_to_array($generator);
+    sort($actual);
 
-	assert($actual === $expected);
+    assert($actual === $expected);
 }
 

--- a/tests/test-result-formatter.php
+++ b/tests/test-result-formatter.php
@@ -2,52 +2,49 @@
 
 namespace EasyTestTest\ResultFormatter;
 
-use EasyTest\Attribute\Fixture;
 use EasyTest\Attribute\Test;
 use EasyTest\ResultFormatter;
 
 #[Test]
 function testResultFormatter_Format_WhenNoFailuresAndErrors_ReturnsMatchingString(): void
 {
-	$passes = 1;
-	$failures = [];
-	$errors = [];
-	$formatter = new ResultFormatter();
+    $passes = 1;
+    $failures = [];
+    $errors = [];
+    $formatter = new ResultFormatter();
 
-	$actual = $formatter->format($passes, $failures, $errors);
+    $actual = $formatter->format($passes, $failures, $errors);
 
-	$expected = <<<EOT
-	All tests passed.
-	
-	EOT;
-	assert($expected === $actual, "'''$expected''' === '''$actual'''");
+    $expected = <<<EOT
+    All tests passed.
+    
+    EOT;
+    assert($expected === $actual, "'''$expected''' === '''$actual'''");
 }
 
 #[Test]
 function testResultFormatter_Format_WithFailure_ReturnsMatchingString(): void
 {
-	$passes = 1;
-	$failures = [new \AssertionError('Failed test message')];
-	$errors = [];
-	$formatter = new ResultFormatter();
+    $passes = 1;
+    $failures = [new \AssertionError('Failed test message')];
+    $errors = [];
+    $formatter = new ResultFormatter();
 
-	$formattedResult = $formatter->format($passes, $failures, $errors);
+    $formattedResult = $formatter->format($passes, $failures, $errors);
 
-
-	assert(strpos($formattedResult, 'Failed test message') !== false);
+    assert(strpos($formattedResult, 'Failed test message') !== false);
 }
 
 #[Test]
 function testResultFormatter_Format_WithError_ReturnsMatchingString(): void
 {
-	$passes = 1;
-	$failures = [];
-	$errors = [new \Error('Error test message')];
-	$formatter = new ResultFormatter();
+    $passes = 1;
+    $failures = [];
+    $errors = [new \Error('Error test message')];
+    $formatter = new ResultFormatter();
 
-	$formattedResult = $formatter->format($passes, $failures, $errors);
+    $formattedResult = $formatter->format($passes, $failures, $errors);
 
-
-	assert(strpos($formattedResult, 'Error test message') !== false);
+    assert(strpos($formattedResult, 'Error test message') !== false);
 }
 

--- a/tests/test-runner.php
+++ b/tests/test-runner.php
@@ -7,11 +7,11 @@ use EasyTest\Attribute\Fixture;
 
 #[Fixture]
 function runner(): \EasyTest\Runner {
-	return new \EasyTest\Runner();
+    return new \EasyTest\Runner();
 }
 
 #[Test]
 function test_runner(\EasyTest\Runner $runner): void
 {
-	assert($runner instanceof \EasyTest\Runner);
+    assert($runner instanceof \EasyTest\Runner);
 }

--- a/tests/test-test-arguments.php
+++ b/tests/test-test-arguments.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace EasyTestTest\TestArguments;
+
+use EasyTest\Attribute\Fixture;
+use EasyTest\Attribute\Test;
+use EasyTest\TestArguments;
+use EasyTest\TestSuite;
+use Generator;
+
+#[Test]
+function testTestArguments_Prepare_WhenFixtureProvided_ReturnsArrayWithFixtureValue(): void
+{
+	$testSuite = new TestSuite([
+		'\\EasyTestTest\\TestArguments\\exampleFixture',
+	]);
+	$testSuite->prepare();
+
+	$actual = TestArguments::prepare($testSuite, ['EasyTestTest\\TestArguments\\exampleFixture' => 'int']);
+
+	$expected = [ 1 ];
+	assert($expected === $actual->getPrepared(), 'Expected: ' . var_export($expected, true) . '. Actual: ' . var_export($actual->getPrepared(), true));
+}
+
+#[Test]
+function testTestArguments_HasGenerators_WhenNoGeneratorProvided_ReturnsFalse(): void
+{
+	$testArguments = new TestArguments([1]);
+
+	assert(!$testArguments->hasGenerators());
+}
+
+#[Test]
+function testTestArguments_HasGenerators_WhenGeneratorProvided_ReturnsTrue(): void
+{
+	$generator = (function () {
+		yield 1;
+	})();
+	
+	$testArguments = new TestArguments([1, $generator]);
+
+	assert($testArguments->hasGenerators());
+}
+
+#[Test]
+function testTestArguments_FindGenerator_WhenNoGeneratorProvided_ReturnsNull(): void
+{
+	$testArguments = new TestArguments([1]);
+
+	$actual = $testArguments->findGenerator();
+
+	assert(null === $actual, 'Expected: null. Actual: ' . var_export($actual, true));
+}
+
+#[Test]
+function testTestArguments_FindGenerator_WhenGeneratorProvided_ReturnsMatchingIndex(): void
+{
+	$generator = (function () {
+		yield 2;
+	})();
+	$testArguments = new TestArguments([1, $generator]);
+
+	$actual = $testArguments->findGenerator();
+
+	assert(1 === $actual, 'Expected: 1. Actual: ' . var_export($actual, true));
+}
+
+#[Fixture]
+function exampleFixture(): int {
+	return 1;
+}
+

--- a/tests/test-test-arguments.php
+++ b/tests/test-test-arguments.php
@@ -11,62 +11,62 @@ use Generator;
 #[Test]
 function testTestArguments_Prepare_WhenFixtureProvided_ReturnsArrayWithFixtureValue(): void
 {
-	$testSuite = new TestSuite([
-		'\\EasyTestTest\\TestArguments\\exampleFixture',
-	]);
-	$testSuite->prepare();
+    $testSuite = new TestSuite([
+        '\\EasyTestTest\\TestArguments\\exampleFixture',
+    ]);
+    $testSuite->prepare();
 
-	$actual = TestArguments::prepare($testSuite, ['EasyTestTest\\TestArguments\\exampleFixture' => 'int']);
+    $actual = TestArguments::prepare($testSuite, ['EasyTestTest\\TestArguments\\exampleFixture' => 'int']);
 
-	$expected = [ 1 ];
-	assert($expected === $actual->getPrepared(), 'Expected: ' . var_export($expected, true) . '. Actual: ' . var_export($actual->getPrepared(), true));
+    $expected = [ 1 ];
+    assert($expected === $actual->getPrepared(), 'Expected: ' . var_export($expected, true) . '. Actual: ' . var_export($actual->getPrepared(), true));
 }
 
 #[Test]
 function testTestArguments_HasGenerators_WhenNoGeneratorProvided_ReturnsFalse(): void
 {
-	$testArguments = new TestArguments([1]);
+    $testArguments = new TestArguments([1]);
 
-	assert(!$testArguments->hasGenerators());
+    assert(!$testArguments->hasGenerators());
 }
 
 #[Test]
 function testTestArguments_HasGenerators_WhenGeneratorProvided_ReturnsTrue(): void
 {
-	$generator = (function () {
-		yield 1;
-	})();
-	
-	$testArguments = new TestArguments([1, $generator]);
+    $generator = (function () {
+        yield 1;
+    })();
+    
+    $testArguments = new TestArguments([1, $generator]);
 
-	assert($testArguments->hasGenerators());
+    assert($testArguments->hasGenerators());
 }
 
 #[Test]
 function testTestArguments_FindGenerator_WhenNoGeneratorProvided_ReturnsNull(): void
 {
-	$testArguments = new TestArguments([1]);
+    $testArguments = new TestArguments([1]);
 
-	$actual = $testArguments->findGenerator();
+    $actual = $testArguments->findGenerator();
 
-	assert(null === $actual, 'Expected: null. Actual: ' . var_export($actual, true));
+    assert(null === $actual, 'Expected: null. Actual: ' . var_export($actual, true));
 }
 
 #[Test]
 function testTestArguments_FindGenerator_WhenGeneratorProvided_ReturnsMatchingIndex(): void
 {
-	$generator = (function () {
-		yield 2;
-	})();
-	$testArguments = new TestArguments([1, $generator]);
+    $generator = (function () {
+        yield 2;
+    })();
+    $testArguments = new TestArguments([1, $generator]);
 
-	$actual = $testArguments->findGenerator();
+    $actual = $testArguments->findGenerator();
 
-	assert(1 === $actual, 'Expected: 1. Actual: ' . var_export($actual, true));
+    assert(1 === $actual, 'Expected: 1. Actual: ' . var_export($actual, true));
 }
 
 #[Fixture]
 function exampleFixture(): int {
-	return 1;
+    return 1;
 }
 

--- a/tests/test-test-suite-runner.php
+++ b/tests/test-test-suite-runner.php
@@ -3,9 +3,6 @@
 namespace EasyTestTest\TestSuiteRunner;
 
 use EasyTest\Attribute\Fixture;
-use EasyTest\Attribute\Ignore;
-use EasyTest\Attribute\Setup;
-use EasyTest\Attribute\TearDown;
 use EasyTest\Attribute\Test;
 use EasyTest\TestSuite;
 use EasyTest\TestSuiteRunner;
@@ -13,58 +10,58 @@ use EasyTest\TestSuiteRunner;
 #[Fixture]
 function runner(): TestSuiteRunner
 {
-	$testSuite = new TestSuite(['EasyTestTest\\TestSuiteRunner\\test_one', 'EasyTestTest\\TestSuiteRunner\\test_one']);
-	$testSuite->prepare();
+    $testSuite = new TestSuite(['EasyTestTest\\TestSuiteRunner\\test_one', 'EasyTestTest\\TestSuiteRunner\\test_one']);
+    $testSuite->prepare();
 
-	return new TestSuiteRunner($testSuite);
+    return new TestSuiteRunner($testSuite);
 }
 
 #[Test]
 function testTestSuiteRunner_Run_WhenCalled_YieldsResuts(TestSuiteRunner $runner): void {
-	$results = $runner->run();
-	
-	$actual = iterator_to_array($results);
-	$expected = ['.', '.'];
-	assert($actual === $expected);
+    $results = $runner->run();
+    
+    $actual = iterator_to_array($results);
+    $expected = ['.', '.'];
+    assert($actual === $expected);
 }
 
 #[Test]
 function testTestSuiteRunner_GetPasses_AfterRun_ReturnsPasses(TestSuiteRunner $runner): void {
-	$result = $runner->run();
-	iterator_to_array($result);
+    $result = $runner->run();
+    iterator_to_array($result);
 
-	$passes = $runner->getPasses();
+    $passes = $runner->getPasses();
 
-	assert($passes === 2, "$passes === 2");
+    assert($passes === 2, "$passes === 2");
 }
 
 #[Test]
 function testTestSuiteRunner_GetFailures_AfterRun_ReturnsEmptyArray(TestSuiteRunner $runner): void {
-	$result = $runner->run();
-	iterator_to_array($result);
+    $result = $runner->run();
+    iterator_to_array($result);
 
-	$failures = $runner->getFailures();
+    $failures = $runner->getFailures();
 
-	assert([] === $failures);
+    assert([] === $failures);
 }
 
 #[Test]
 function testTestSuiteRunner_GetErrors_AfterRun_ReturnsEmptyArray(TestSuiteRunner $runner): void {
-	$result = $runner->run();
-	iterator_to_array($result);
+    $result = $runner->run();
+    iterator_to_array($result);
 
-	$errors = $runner->getErrors();
+    $errors = $runner->getErrors();
 
-	assert([] === $errors);
+    assert([] === $errors);
 }
 
 #[Test]
 function test_one(): void {
-	assert(true);
+    assert(true);
 }
 
 #[Test]
 function test_two(): void {
-	assert(true);
+    assert(true);
 }
 

--- a/tests/test-test-suite.php
+++ b/tests/test-test-suite.php
@@ -8,21 +8,13 @@ use EasyTest\TestSuite;
 use Generator;
 
 #[Test]
-function testTestSuite_GetTests_WhenPrepareCalled_ReturnsMatchingArray(TestSuite $testSuite): void
+function testTestSuite_GetTests_WhenPrepareCalled_ReturnsArrayOfMatchingSize(TestSuite $testSuite): void
 {
 	$testSuite->prepare();
 
 	$actual = $testSuite->getTests();
 
-	$expected = [
-		[
-			'function' => 'EasyTestTest\\TestSuite\\exampleTest',
-			'arguments' => [
-				'EasyTestTest\\TestSuite\\exampleFixture' => 'int',
-			],
-		],
-	];
-	assert($expected === $actual, 'Expected: ' . json_encode($expected) . ' Actual: ' . json_encode($actual));
+	assert(1 === count($actual), 'Expected: 1. Actual: ' . count($actual));
 }
 
 #[Test]

--- a/tests/test-test-suite.php
+++ b/tests/test-test-suite.php
@@ -3,9 +3,9 @@
 namespace EasyTestTest\TestSuite;
 
 use EasyTest\Attribute\Fixture;
-use EasyTest\Attribute\Ignore;
 use EasyTest\Attribute\Test;
 use EasyTest\TestSuite;
+use Generator;
 
 #[Test]
 function testTestSuite_GetTests_WhenPrepareCalled_ReturnsMatchingArray(TestSuite $testSuite): void
@@ -36,9 +36,9 @@ function testTestSuite_GetFixture_WhenNameAndTypeProvided_ReturnsMatchingFunctio
 }
 
 #[Fixture]
-function testSuite(): TestSuite
+function testSuite(): Generator
 {
-	return new TestSuite([
+	yield new TestSuite([
 		'\\EasyTestTest\\TestSuite\\exampleTest', 
 		'\\EasyTestTest\\TestSuite\\exampleFixture',
 	]);

--- a/tests/test-test-suite.php
+++ b/tests/test-test-suite.php
@@ -10,30 +10,30 @@ use Generator;
 #[Test]
 function testTestSuite_GetTests_WhenPrepareCalled_ReturnsArrayOfMatchingSize(TestSuite $testSuite): void
 {
-	$testSuite->prepare();
+    $testSuite->prepare();
 
-	$actual = $testSuite->getTests();
+    $actual = $testSuite->getTests();
 
-	assert(1 === count($actual), 'Expected: 1. Actual: ' . count($actual));
+    assert(1 === count($actual), 'Expected: 1. Actual: ' . count($actual));
 }
 
 #[Test]
 function testTestSuite_GetFixture_WhenNameAndTypeProvided_ReturnsMatchingFunctionName(TestSuite $testSuite): void
 {
-	$testSuite->prepare();
+    $testSuite->prepare();
 
-	$actual = $testSuite->hasFixture('EasyTestTest\\TestSuite\\exampleFixture', 'int');
+    $actual = $testSuite->hasFixture('EasyTestTest\\TestSuite\\exampleFixture', 'int');
 
-	assert($actual);
+    assert($actual);
 }
 
 #[Fixture]
 function testSuite(): Generator
 {
-	yield new TestSuite([
-		'\\EasyTestTest\\TestSuite\\exampleTest', 
-		'\\EasyTestTest\\TestSuite\\exampleFixture',
-	]);
+    yield new TestSuite([
+    	'\\EasyTestTest\\TestSuite\\exampleTest', 
+    	'\\EasyTestTest\\TestSuite\\exampleFixture',
+    ]);
 }
 
 #[Test]
@@ -43,5 +43,5 @@ function exampleTest(int $exampleFixture): void {
 
 #[Fixture] 
 function exampleFixture(): int {
-	return 1;
+    return 1;
 }

--- a/tests/test-test.php
+++ b/tests/test-test.php
@@ -10,66 +10,66 @@ use EasyTest\TestSuiteInterface;
 #[Test]
 function testTest_Run_WhenNoArguments_RunsTestFunction(): void
 {
-	GlobalScope::$var = 0;
-	$testSuite = new TestSuiteMock();
-	$test = new TestCase($testSuite, 'EasyTestTest\\Test\\test_function', []);
+    GlobalScope::$var = 0;
+    $testSuite = new TestSuiteMock();
+    $test = new TestCase($testSuite, 'EasyTestTest\\Test\\test_function', []);
 
-	$test->run();
+    $test->run();
 
-	assert(GlobalScope::$var === 1);
+    assert(GlobalScope::$var === 1);
 }
 
 #[Test]
 function testTest_Run_WhenArgumentWithGenerator_RunsTestFunctionForEachGeneratorValue(): void
 {
-	GlobalScope::$var = 0;
-	$testSuite = new TestSuiteMock();
-	$test = new TestCase(
-		$testSuite, 
-		'EasyTestTest\\Test\\test_function_with_generator_argument', 
-		['EasyTestTest\\Test\\generator_fixture' => 'int']
-	);
+    GlobalScope::$var = 0;
+    $testSuite = new TestSuiteMock();
+    $test = new TestCase(
+        $testSuite, 
+        'EasyTestTest\\Test\\test_function_with_generator_argument', 
+        ['EasyTestTest\\Test\\generator_fixture' => 'int']
+    );
 
-	$test->run();
+    $test->run();
 
-	assert(GlobalScope::$var === 6);
+    assert(GlobalScope::$var === 6);
 }
 
 class TestSuiteMock implements TestSuiteInterface {
 
     public function prepare(): void { }
 
-	public function getTests(): array {
-		return [];
-	}
+    public function getTests(): array {
+        return [];
+    }
 
-	public function hasFixture(string $fixtureName, string $fixtureType): bool {
-		return true;
-	}
+    public function hasFixture(string $fixtureName, string $fixtureType): bool {
+        return true;
+    }
 
-	public function getSetups(): array {
-		return [];
-	}
+    public function getSetups(): array {
+        return [];
+    }
 
-	public function getTearDowns(): array {
-		return [];
-	}
+    public function getTearDowns(): array {
+        return [];
+    }
 }
 
 class GlobalScope {
-	public static int $var = 0;
+    public static int $var = 0;
 } 
 
 function test_function() {
-	GlobalScope::$var = 1;
+    GlobalScope::$var = 1;
 }
 
 function test_function_with_generator_argument(int $generator_fixture) {
-	GlobalScope::$var += $generator_fixture;
+    GlobalScope::$var += $generator_fixture;
 }
 
 function generator_fixture(): \Generator {
-	yield 1;
-	yield 2;
-	yield 3;
+    yield 1;
+    yield 2;
+    yield 3;
 }

--- a/tests/test-test.php
+++ b/tests/test-test.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace EasyTestTest\Test;
+
+use EasyTest\Attribute\Test;
+use EasyTest\Test as TestCase;
+use EasyTest\TestSuiteInterface;
+
+
+#[Test]
+function testTest_Run_WhenNoArguments_RunsTestFunction(): void
+{
+	GlobalScope::$var = 0;
+	$testSuite = new TestSuiteMock();
+	$test = new TestCase($testSuite, 'EasyTestTest\\Test\\test_function', []);
+
+	$test->run();
+
+	assert(GlobalScope::$var === 1);
+}
+
+#[Test]
+function testTest_Run_WhenArgumentWithGenerator_RunsTestFunctionForEachGeneratorValue(): void
+{
+	GlobalScope::$var = 0;
+	$testSuite = new TestSuiteMock();
+	$test = new TestCase(
+		$testSuite, 
+		'EasyTestTest\\Test\\test_function_with_generator_argument', 
+		['EasyTestTest\\Test\\generator_fixture' => 'int']
+	);
+
+	$test->run();
+
+	assert(GlobalScope::$var === 6);
+}
+
+class TestSuiteMock implements TestSuiteInterface {
+
+    public function prepare(): void { }
+
+	public function getTests(): array {
+		return [];
+	}
+
+	public function hasFixture(string $fixtureName, string $fixtureType): bool {
+		return true;
+	}
+
+	public function getSetups(): array {
+		return [];
+	}
+
+	public function getTearDowns(): array {
+		return [];
+	}
+}
+
+class GlobalScope {
+	public static int $var = 0;
+} 
+
+function test_function() {
+	GlobalScope::$var = 1;
+}
+
+function test_function_with_generator_argument(int $generator_fixture) {
+	GlobalScope::$var += $generator_fixture;
+}
+
+function generator_fixture(): \Generator {
+	yield 1;
+	yield 2;
+	yield 3;
+}


### PR DESCRIPTION
## Changes

- Introduce TestArguments class
- Introduce Test class
- Introduce TestSuiteInterface
- Allow fixtures return generators

## Goal

The main idea here is to allow fixtures return generators.
If you're familiar with data providers in PHPUnit, that's something very similar.